### PR TITLE
Remove the default value from header.remote_user

### DIFF
--- a/src/main/java/net/shibboleth/tools/jira/authn/ShibAuthConfigLoader.java
+++ b/src/main/java/net/shibboleth/tools/jira/authn/ShibAuthConfigLoader.java
@@ -154,7 +154,7 @@ public class ShibAuthConfigLoader {
             }
 
             config.setDefaultRoles(defaultRoles);
-            config.setRemoteUserHeaderName(configProps.getProperty(ShibAuthConstants.REMOTE_USER_HEADER_NAME_PROPERTY, "REMOTE_USER"));
+            config.setRemoteUserHeaderName(configProps.getProperty(ShibAuthConstants.REMOTE_USER_HEADER_NAME_PROPERTY));
 
             if (log.isDebugEnabled()) {
                 log.debug("HTTP Header that may contain user's username set to: " + config.getRemoteUserHeaderName());


### PR DESCRIPTION
Remove the default value on the header.remote_user parameter, as this masks the ability to use AJP+REMOTE_USER with tomcatAuthentication=false.