### PR TITLE
Use new Atlassian maven proxy repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
     <packaging>jar</packaging>
     <repositories>
         <repository>
-            <id>Atlassian Public</id>
-            <url>https://maven.atlassian.com/content/repositories/atlassian-public/</url>
+            <id>Atlassian Maven Proxy</id>
+            <url>https://packages.atlassian.com/maven/repository/public</url>
         </repository>
         <repository>
             <id>Spring IO</id>


### PR DESCRIPTION
According to
https://developer.atlassian.com/server/framework/atlassian-sdk/working-with-maven/#atlassian-maven-repositories their maven proxy repo URL has changed, so update to the new one.

This was triggered by that we couldn't build because of missing dependencies in the configured repos (webwork IIRC).